### PR TITLE
command piping

### DIFF
--- a/examples/sandbox.rs
+++ b/examples/sandbox.rs
@@ -14,7 +14,7 @@ fn setup(mut commands: Commands) {
         n: 3,
     });
     commands.create_stuff(TransformBundle::default(), 3);
-    commands.error_out();
+    commands.error_out(true);
 }
 
 fn check(query: Query<Entity, With<Transform>>) {
@@ -36,6 +36,11 @@ fn report_error(In(error): In<&'static str>) {
 }
 
 #[command(err = report_error)]
-fn error_out(world: &mut World) -> Result<(), &'static str> {
-    Err("something went wrong")
+fn error_out(world: &mut World, success: bool) -> Result<(), &'static str> {
+    if success {
+        println!("Everything is fine");
+        Ok(())
+    } else {
+        Err("Something went wrong")
+    }
 }

--- a/examples/sandbox.rs
+++ b/examples/sandbox.rs
@@ -1,6 +1,5 @@
 use bevy::prelude::*;
 use bevy_commandify::*;
-use bevy_ecs::system::RunSystemOnce;
 
 fn main() {
     App::new()
@@ -14,7 +13,9 @@ fn setup(mut commands: Commands) {
         n: 3,
     });
     commands.create_stuff(TransformBundle::default(), 3);
+
     commands.error_out(true);
+    commands.error_out(false);
 }
 
 fn check(query: Query<Entity, With<Transform>>) {
@@ -31,16 +32,21 @@ fn create_stuff<B: Bundle + Clone>(world: &mut World, bundle: B, n: usize) {
     }
 }
 
+fn handle_ok(In(value): In<u32>) {
+    println!("Everything is fine. See: {}", value);
+}
+
 fn report_error(In(error): In<&'static str>) {
     println!("Handling an Error: {:?}", error);
 }
 
-#[command(err = report_error)]
-fn error_out(world: &mut World, success: bool) -> Result<(), &'static str> {
+#[command(ok = handle_ok, err = report_error)]
+fn error_out(world: &mut World, success: bool) -> Result<u32, &'static str> {
     if success {
-        println!("Everything is fine");
-        Ok(())
+        println!("Testing ok handler...");
+        Ok(42)
     } else {
+        println!("Testing err handler...");
         Err("Something went wrong")
     }
 }

--- a/examples/sandbox.rs
+++ b/examples/sandbox.rs
@@ -16,6 +16,8 @@ fn setup(mut commands: Commands) {
 
     commands.error_out(true);
     commands.error_out(false);
+    commands.only_ok();
+    commands.only_err();
 }
 
 fn check(query: Query<Entity, With<Transform>>) {
@@ -37,16 +39,24 @@ fn handle_ok(In(value): In<u32>) {
 }
 
 fn report_error(In(error): In<&'static str>) {
-    println!("Handling an Error: {:?}", error);
+    println!("Error: {}", error);
 }
 
 #[command(ok = handle_ok, err = report_error)]
 fn error_out(world: &mut World, success: bool) -> Result<u32, &'static str> {
     if success {
-        println!("Testing ok handler...");
         Ok(42)
     } else {
-        println!("Testing err handler...");
         Err("Something went wrong")
     }
+}
+
+#[command(ok = handle_ok)]
+fn only_ok(world: &mut World) -> Result<u32, &'static str> {
+    Ok(3)
+}
+
+#[command(err = report_error)]
+fn only_err(world: &mut World) -> Result<u32, &'static str> {
+    Err("It's okay to be in error.")
 }

--- a/examples/sandbox.rs
+++ b/examples/sandbox.rs
@@ -18,6 +18,7 @@ fn setup(mut commands: Commands) {
     commands.error_out(false);
     commands.only_ok();
     commands.only_err();
+    commands.pipe_test(23);
 }
 
 fn check(query: Query<Entity, With<Transform>>) {
@@ -59,4 +60,13 @@ fn only_ok(world: &mut World) -> Result<u32, &'static str> {
 #[command(err = report_error)]
 fn only_err(world: &mut World) -> Result<u32, &'static str> {
     Err("It's okay to be in error.")
+}
+
+fn green_pipe(In(value): In<i32>) {
+    println!("Got {value} through the green pipe.");
+}
+
+#[command(pipe = green_pipe)]
+fn pipe_test(world: &mut World, some_value: i32) -> i32 {
+    some_value * 77
 }

--- a/examples/sandbox.rs
+++ b/examples/sandbox.rs
@@ -1,5 +1,6 @@
 use bevy::prelude::*;
 use bevy_commandify::*;
+use bevy_ecs::system::RunSystemOnce;
 
 fn main() {
     App::new()
@@ -13,6 +14,7 @@ fn setup(mut commands: Commands) {
         n: 3,
     });
     commands.create_stuff(TransformBundle::default(), 3);
+    commands.error_out();
 }
 
 fn check(query: Query<Entity, With<Transform>>) {
@@ -27,4 +29,13 @@ fn create_stuff<B: Bundle + Clone>(world: &mut World, bundle: B, n: usize) {
     for _ in 0..n {
         world.spawn(bundle.clone());
     }
+}
+
+fn report_error(In(error): In<&'static str>) {
+    println!("Handling an Error: {:?}", error);
+}
+
+#[command(err = report_error)]
+fn error_out(world: &mut World) -> Result<(), &'static str> {
+    Err("something went wrong")
 }

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -48,6 +48,7 @@ pub fn commandify(
         struct_name,
         trait_name,
         ecs_root,
+        ok_handler,
         error_handler,
     } = parse::macro_args(&args, ident.clone())?;
 
@@ -167,9 +168,11 @@ pub fn commandify(
             quote!(#fn_ident(world, #(#def_field_names,)*))
         };
         Some(quote!({
+            use #ecs_root ::system::RunSystemOnce;
             let result = #fn_call;
-            if let Err(error) = result {
-                world.run_system_once_with(error, #error_handler);
+            match result {
+                Ok(ok) => world.run_system_once_with(ok, #ok_handler),
+                Err(error) => world.run_system_once_with(error, #error_handler),
             }
         }))
     } else {

--- a/src/gen.rs
+++ b/src/gen.rs
@@ -169,7 +169,7 @@ pub fn commandify(
 
     let fn_ident = match output_handler {
         OutputHandler::Result => Ident::new(&format!("{}_with_result", ident), ident.span()),
-        OutputHandler::Pipe => Ident::new(&format!("{}_with_pipe", ident), ident.span()),
+        OutputHandler::Pipe => Ident::new(&format!("{}_with_output", ident), ident.span()),
         OutputHandler::None => ident.clone(),
     };
 

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -15,6 +15,7 @@ pub struct MacroArgs {
     pub struct_name: Option<Ident>,
     pub trait_name: Option<Ident>,
     pub ecs_root: Option<Path>,
+    pub ok_handler: Option<Ident>,
     pub error_handler: Option<Ident>,
 }
 
@@ -26,6 +27,7 @@ pub fn macro_args(args: &Punctuated<Meta, Comma>, mut name: Ident) -> Result<Mac
     let mut struct_name = None;
     let mut trait_name = None;
     let mut ecs_root = None;
+    let mut ok_handler = None;
     let mut error_handler = None;
 
     // parse macro arguments
@@ -52,6 +54,9 @@ pub fn macro_args(args: &Punctuated<Meta, Comma>, mut name: Ident) -> Result<Mac
             Meta::NameValue(MetaNameValue { path, value, .. }) if path.is_ident("ecs") => {
                 ecs_root = Some(value.try_to_path()?);
             }
+            Meta::NameValue(MetaNameValue { path, value, .. }) if path.is_ident("ok") => {
+                ok_handler = Some(value.try_to_ident()?);
+            }
             Meta::NameValue(MetaNameValue { path, value, .. }) if path.is_ident("err") => {
                 error_handler = Some(value.try_to_ident()?);
             }
@@ -71,6 +76,7 @@ pub fn macro_args(args: &Punctuated<Meta, Comma>, mut name: Ident) -> Result<Mac
         struct_name,
         trait_name,
         ecs_root,
+        ok_handler,
         error_handler,
     })
 }

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -141,7 +141,7 @@ pub fn fn_args(inputs: &Punctuated<FnArg, Comma>, entity_command: bool) -> Resul
                     Type::Path(path) => {
                         if let Some(seg) = path.path.segments.last() {
                             let ident = &seg.ident;
-                            if entity_command && ident == "Entity" {
+                            if entity_command && ident == "Entity" && entity_field.is_none() {
                                 entity_field = Some(quote!(#pt));
                                 continue;
                             } else if ident == "In" {

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -17,6 +17,7 @@ pub struct MacroArgs {
     pub ecs_root: Option<Path>,
     pub ok_handler: Option<Ident>,
     pub error_handler: Option<Ident>,
+    pub pipe_destination: Option<Ident>,
 }
 
 /// parse macro args
@@ -29,6 +30,7 @@ pub fn macro_args(args: &Punctuated<Meta, Comma>, mut name: Ident) -> Result<Mac
     let mut ecs_root = None;
     let mut ok_handler = None;
     let mut error_handler = None;
+    let mut pipe_destination = None;
 
     // parse macro arguments
     for meta in args {
@@ -60,6 +62,9 @@ pub fn macro_args(args: &Punctuated<Meta, Comma>, mut name: Ident) -> Result<Mac
             Meta::NameValue(MetaNameValue { path, value, .. }) if path.is_ident("err") => {
                 error_handler = Some(value.try_to_ident()?);
             }
+            Meta::NameValue(MetaNameValue { path, value, .. }) if path.is_ident("pipe") => {
+                pipe_destination = Some(value.try_to_ident()?);
+            }
             _ => {
                 return Err(Error::new(
                     meta.span(),
@@ -78,6 +83,7 @@ pub fn macro_args(args: &Punctuated<Meta, Comma>, mut name: Ident) -> Result<Mac
         ecs_root,
         ok_handler,
         error_handler,
+        pipe_destination,
     })
 }
 
@@ -298,13 +304,7 @@ pub fn return_type(output: &ReturnType) -> Result<bool, Error> {
             {
                 true
             }
-            _ => false, // Type::Path(tp) if is_result(tp) => false,
-                        // _ => {
-                        //     return Err(Error::new(
-                        //         ty.span(),
-                        //         "command may not define a return type, except for `&mut Self`",
-                        //     ))
-                        // }
+            _ => false,
         },
         _ => false,
     };

--- a/tests/chaining.rs
+++ b/tests/chaining.rs
@@ -28,7 +28,7 @@ fn chain_commands() {
     world.insert_resource(TestUsize(30));
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     // method call on Commands
     commands.foo(10).foo(10);
@@ -48,7 +48,7 @@ fn chain_entity_commands() {
     let entity = world.spawn(TestUsize(30)).id();
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     // method call on Commands
     commands.entity(entity).bar(10).bar(10);
@@ -69,7 +69,7 @@ fn spawn_chain_commands() {
     let mut world = World::new();
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     // The operation effectively does nothing since we replace it right after
     commands.spawn(TestUsize(10)).bar(5).insert(TestUsize(100));

--- a/tests/ecs_path.rs
+++ b/tests/ecs_path.rs
@@ -17,7 +17,7 @@ fn ecs_name() {
     let mut world = World::new();
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     // Call via Commands
     commands.foo();

--- a/tests/entity_command.rs
+++ b/tests/entity_command.rs
@@ -15,7 +15,7 @@ fn marker_applied() {
     let mut world = World::new();
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     let mut entity_commands = commands.spawn_empty();
     let id = entity_commands.id();

--- a/tests/no_trait.rs
+++ b/tests/no_trait.rs
@@ -13,7 +13,7 @@ fn struct_command_still_works() {
     let mut world = World::new();
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     commands.add(FooCommand);
     commands.spawn_empty().add(BarEntityCommand);

--- a/tests/output_pipe.rs
+++ b/tests/output_pipe.rs
@@ -1,0 +1,33 @@
+use bevy::ecs::system::CommandQueue;
+use bevy::prelude::*;
+use bevy_commandify::*;
+
+const TEST_VALUE: i32 = 33;
+
+#[derive(Resource)]
+struct OutputPiped;
+
+fn process_input(In(value): In<i32>, mut commands: Commands) {
+    if value == TEST_VALUE {
+        commands.insert_resource(OutputPiped);
+    }
+}
+
+#[command(pipe = process_input)]
+fn test_pipe(world: &mut World, value: i32) -> i32 {
+    return value;
+}
+
+#[test]
+fn can_pipe_output() {
+    let mut world = World::new();
+
+    let mut queue = CommandQueue::default();
+    let mut commands = Commands::new(&mut queue, &world);
+
+    commands.add(TestPipeCommand { value: TEST_VALUE });
+
+    queue.apply(&mut world);
+
+    assert!(world.get_resource::<OutputPiped>().is_some());
+}

--- a/tests/rename.rs
+++ b/tests/rename.rs
@@ -27,7 +27,7 @@ fn foo_becomes_sub() {
     world.insert_resource(TestUsize(30));
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     // method call on Commands
     commands.sub(10);
@@ -53,7 +53,7 @@ fn bar_becomes_bus() {
     let entity = world.spawn(TestUsize(30)).id();
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     // method call on Commands
     commands.entity(entity).bus(10);

--- a/tests/rename_struct.rs
+++ b/tests/rename_struct.rs
@@ -27,7 +27,7 @@ fn renamed_struct() {
     world.insert_resource(TestUsize(10));
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     // Call via Commands
     commands.add(Foo { n: 10 });
@@ -44,7 +44,7 @@ fn renamed_entity_struct() {
     let entity = world.spawn(TestUsize(20)).id();
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     commands.entity(entity).add(Bar { n: 10 });
     commands.entity(entity).do_sub(10);

--- a/tests/rename_trait.rs
+++ b/tests/rename_trait.rs
@@ -27,7 +27,7 @@ fn renamed_trait() {
     world.insert_resource(TestUsize(10));
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     // Call via Commands
     FooExt::add(&mut commands, 10);
@@ -47,7 +47,7 @@ fn renamed_entity_trait() {
     let entity = world.spawn(TestUsize(30)).id();
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     // Call via Commands
     BarExt::do_sub(&mut commands.entity(entity), 10);

--- a/tests/result_handlers.rs
+++ b/tests/result_handlers.rs
@@ -1,0 +1,54 @@
+use bevy::ecs::system::CommandQueue;
+use bevy::prelude::*;
+use bevy_commandify::*;
+
+#[derive(Resource)]
+struct OkHandled;
+
+#[derive(Resource)]
+struct ErrorHandled;
+
+fn handle_ok(In(_): In<bool>, mut commands: Commands) {
+    commands.insert_resource(OkHandled);
+}
+
+fn handle_err(In(_): In<bool>, mut commands: Commands) {
+    commands.insert_resource(ErrorHandled);
+}
+
+#[command(ok = handle_ok, err = handle_err)]
+fn test_handler(world: &mut World, success: bool) -> Result<bool, bool> {
+    if success {
+        Ok(true)
+    } else {
+        Err(false)
+    }
+}
+
+#[test]
+fn error_handler_handles_err() {
+    let mut world = World::new();
+
+    let mut queue = CommandQueue::default();
+    let mut commands = Commands::new(&mut queue, &world);
+
+    commands.add(TestHandlerCommand { success: false });
+
+    queue.apply(&mut world);
+
+    assert!(world.get_resource::<ErrorHandled>().is_some());
+}
+
+#[test]
+fn error_handler_handles_ok() {
+    let mut world = World::new();
+
+    let mut queue = CommandQueue::default();
+    let mut commands = Commands::new(&mut queue, &world);
+
+    commands.add(TestHandlerCommand { success: true });
+
+    queue.apply(&mut world);
+
+    assert!(world.get_resource::<OkHandled>().is_some());
+}

--- a/tests/simple.rs
+++ b/tests/simple.rs
@@ -30,7 +30,7 @@ fn command() {
     world.insert_resource(TestUsize(50));
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     // method call on Commands
     commands.foo(5);
@@ -56,7 +56,7 @@ fn entity_command() {
     let entity = world.spawn(TestUsize(50)).id();
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     // method call on Commands
     commands.entity(entity).bar(5);

--- a/tests/systemify.rs
+++ b/tests/systemify.rs
@@ -46,7 +46,7 @@ fn command() {
     schedule.run(&mut world);
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     // subtract 5 for irony and (5*2)+0 for one
     commands.irony().one((5, 0));
@@ -66,7 +66,7 @@ fn entity_command() {
     let entity = world.spawn(TestUsize(30)).id();
 
     let mut queue = CommandQueue::default();
-    let mut commands = Commands::new(&mut queue, &mut world);
+    let mut commands = Commands::new(&mut queue, &world);
 
     // method call on Commands
     commands.entity(entity).two(5);

--- a/tests/ui/bad_path.stderr
+++ b/tests/ui/bad_path.stderr
@@ -2,4 +2,4 @@ error: Name must be an ident, found path
  --> tests/ui/bad_path.rs:3:18
   |
 3 | #[command(name = foo::bar)]
-  |                  ^^^^^^^^
+  |                  ^^^

--- a/tests/ui/no_handler.rs
+++ b/tests/ui/no_handler.rs
@@ -1,0 +1,7 @@
+use bevy_commandify::*;
+
+#[command(ok=)]
+fn foo(world: &mut World) { }
+
+/// Test that a command with a handler specifies the handler.
+fn main() { }

--- a/tests/ui/no_handler.stderr
+++ b/tests/ui/no_handler.stderr
@@ -1,0 +1,7 @@
+error: unexpected end of input, expected an expression
+ --> tests/ui/no_handler.rs:3:1
+  |
+3 | #[command(ok=)]
+  | ^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `command` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/no_pipe.rs
+++ b/tests/ui/no_pipe.rs
@@ -1,0 +1,7 @@
+use bevy_commandify::*;
+
+#[command(pipe=)]
+fn foo(world: &mut World) { }
+
+/// Test that a command with a pipe specifies the pipe fn.
+fn main() { }

--- a/tests/ui/no_pipe.stderr
+++ b/tests/ui/no_pipe.stderr
@@ -1,0 +1,7 @@
+error: unexpected end of input, expected an expression
+ --> tests/ui/no_pipe.rs:3:1
+  |
+3 | #[command(pipe=)]
+  | ^^^^^^^^^^^^^^^^^
+  |
+  = note: this error originates in the attribute macro `command` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/tests/ui/return_type.rs
+++ b/tests/ui/return_type.rs
@@ -1,6 +1,0 @@
-use bevy_commandify::*;
-
-#[command]
-fn foo(world: &mut World) -> usize { }
-
-fn main() { }

--- a/tests/ui/return_type.stderr
+++ b/tests/ui/return_type.stderr
@@ -1,5 +1,0 @@
-error: command may not define a return type, except for `&mut Self`
- --> tests/ui/return_type.rs:4:30
-  |
-4 | fn foo(world: &mut World) -> usize { }
-  |                              ^^^^^

--- a/tests/ui/return_type_entity.rs
+++ b/tests/ui/return_type_entity.rs
@@ -1,6 +1,0 @@
-use bevy_commandify::*;
-
-#[entity_command]
-fn foo(world: &mut World) -> Command { }
-
-fn main() { }

--- a/tests/ui/return_type_entity.stderr
+++ b/tests/ui/return_type_entity.stderr
@@ -1,5 +1,0 @@
-error: command may not define a return type, except for `&mut Self`
- --> tests/ui/return_type_entity.rs:4:30
-  |
-4 | fn foo(world: &mut World) -> Command { }
-  |                              ^^^^^^^


### PR DESCRIPTION
In progress work on an error handling property.

Goal: Direct output from a command to some arbitrary system.

```rust
fn handle_ok(In(value): In<u32>) {
    println!("Everything is fine. See: {}", value);
}

fn report_error(In(error): In<&'static str>) {
    println!("Error: {}", error);
}

#[command(ok = handle_ok, err = report_error)]
fn error_out(world: &mut World, success: bool) -> Result<u32, &'static str> {
    if success {
        Ok(42)
    } else {
        Err("Something went wrong")
    }
}

#[command(ok = handle_ok)]
fn only_ok(world: &mut World) -> Result<u32, &'static str> {
    Ok(3)
}

#[command(err = report_error)]
fn only_err(world: &mut World) -> Result<u32, &'static str> {
    Err("It's okay to be in error.")
}
```

General pipes are now supported:
```rust
fn do_a_thing(In(value): In<i32>) {
   // value will be the result of command_with_output
}

#[command(pipe = do_a_thing)]
fn command_with_output(world: &mut World) -> i32 {
    7
}
```
